### PR TITLE
Add operation sort and select

### DIFF
--- a/packages/ilorm-connector-mongo/lib/connector/convertQueryToMongoQuery.js
+++ b/packages/ilorm-connector-mongo/lib/connector/convertQueryToMongoQuery.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { OPERATIONS, } = require('ilorm-constants').QUERY;
+const { OPERATIONS, SORT_BEHAVIOR, } = require('ilorm-constants').QUERY;
 
 const operatorConversion = {
   [OPERATIONS.IS]: '$eq',
@@ -12,6 +12,9 @@ const operatorConversion = {
   [OPERATIONS.GREATER_OR_EQUAL_THAN]: '$gte',
   [OPERATIONS.LOWER_OR_EQUAL_THAN]: '$lte',
 };
+
+const ASCENDING = 1;
+const DESCENDING = -1;
 
 /**
  * Convert a valid inputQuery to a query
@@ -45,6 +48,16 @@ function convertQueryToMongoQuery(query) {
       }
 
       mongoOptions.projection[field] = 1;
+    },
+    onSort: (key, order) => {
+      if (!mongoOptions.sort) {
+        mongoOptions.sort = [];
+      }
+
+      mongoOptions.sort.push([
+        key,
+        order === SORT_BEHAVIOR.ASCENDING ? ASCENDING : DESCENDING,
+      ]);
     },
     onOperator: (key, operator, value) => {
       if (!keys[key]) {

--- a/packages/ilorm-connector-mongo/lib/connector/convertQueryToMongoQuery.js
+++ b/packages/ilorm-connector-mongo/lib/connector/convertQueryToMongoQuery.js
@@ -39,6 +39,13 @@ function convertQueryToMongoQuery(query) {
         $or: arrayOfQuery.map(query => convertQueryToMongoQuery(query)),
       });
     },
+    onSelect: ({ field, }) => {
+      if (!mongoOptions.projection) {
+        mongoOptions.projection = {};
+      }
+
+      mongoOptions.projection[field] = 1;
+    },
     onOperator: (key, operator, value) => {
       if (!keys[key]) {
         keys[key] = {};

--- a/packages/ilorm-connector-mongo/test/selectData.test.js
+++ b/packages/ilorm-connector-mongo/test/selectData.test.js
@@ -1,0 +1,93 @@
+/* eslint-disable */
+
+const { expect, } = require('chai');
+const { MongoClient, } = require('mongodb');
+const ilorm = require('ilorm');
+
+const ilormMongo = require('../index');
+
+const DB_URL = 'mongodb://localhost:27017/ilorm';
+
+const { Schema, declareModel, newModel, } = ilorm;
+
+describe('ilorm-connector-mongodb', () => {
+  describe('test/readData', () => {
+
+    let mongoClient;
+    let database;
+    let modelFactoryParams;
+
+    before(async () => {
+
+      mongoClient = await MongoClient.connect(DB_URL);
+      database = await mongoClient.db('ilorm');
+
+
+      ilorm.use(ilormMongo);
+
+      const userSchema = new Schema({
+        firstName: Schema.string().required(),
+        lastName: Schema.string().required(),
+        gender: Schema.string().required()
+      });
+
+      const MongoConnector = ilormMongo.fromClient(database);
+
+      modelFactoryParams = {
+        name: 'users',
+        schema: userSchema,
+        connector: new MongoConnector({
+          collectionName: 'users',
+        }),
+      };
+
+      await database.collection('users').insertMany([
+        {
+          firstName: 'Guillaume',
+          lastName: 'Daix',
+          gender: 'M'
+        }
+      ]);
+
+    });
+
+    after(async () => {
+      await database.dropCollection('users');
+
+      await mongoClient.close();
+    });
+
+    it('Could query only firstName and lastName', async() => {
+      class User extends newModel(modelFactoryParams) {}
+
+      declareModel('users', User);
+
+      const user = await User.query()
+        .firstName.is('Guillaume')
+        .firstName.select()
+        .lastName.select()
+        .findOne();
+
+      expect(user.firstName).to.be.equal('Guillaume');
+      expect(user.lastName).to.be.equal('Daix');
+      expect(user.gender).to.be.equal(undefined);
+    });
+
+    it('Could query only lastName', async() => {
+      class User extends newModel(modelFactoryParams) {}
+
+      declareModel('users', User);
+
+      const lastName = await User.query()
+        .firstName.is('Guillaume')
+        .lastName.selectOnly()
+        .findOne();
+
+      expect(lastName).to.be.equal('Daix');
+    });
+  });
+});
+
+
+
+

--- a/packages/ilorm-constants/lib/query.js
+++ b/packages/ilorm-constants/lib/query.js
@@ -53,5 +53,13 @@ module.exports = {
     // Update :
     SET: 'set',
     ADD: 'add',
+
+    // Sort
+    SORT_ASCENDING: 'useAsSortAsc',
+    SORT_DESCENDING: 'useAsSortDesc',
+
+    // Select
+    SELECT_ONLY: 'selectOnly',
+    SELECT: 'select',
   },
 };

--- a/packages/ilorm-constants/lib/query.js
+++ b/packages/ilorm-constants/lib/query.js
@@ -39,6 +39,11 @@ module.exports = {
     ONE: Symbol('selectOne'),
   },
 
+  SORT_BEHAVIOR: {
+    ASCENDING: Symbol('ascending'),
+    DESCENDING: Symbol('descending'),
+  },
+
   OPERATIONS: {
     // Basic operations :
     IS: 'is',

--- a/packages/ilorm-constants/lib/query.js
+++ b/packages/ilorm-constants/lib/query.js
@@ -25,6 +25,12 @@ module.exports = {
 
     // Declare the number of element to query during the run of the query
     LIMIT: Symbol('limit'),
+
+    // Declare Select specific fields
+    SELECT: Symbol('select'),
+
+    // Declare sort
+    SORT: Symbol('sort'),
   },
 
   OPERATIONS: {

--- a/packages/ilorm-constants/lib/query.js
+++ b/packages/ilorm-constants/lib/query.js
@@ -33,6 +33,12 @@ module.exports = {
     SORT: Symbol('sort'),
   },
 
+  SELECT_BEHAVIOR: {
+    ALL: Symbol('selectAll'),
+    MULTIPLE: Symbol('selectMultiple'),
+    ONE: Symbol('selectOne'),
+  },
+
   OPERATIONS: {
     // Basic operations :
     IS: 'is',

--- a/packages/ilorm-plugin-softDelete/lib/query.factory.js
+++ b/packages/ilorm-plugin-softDelete/lib/query.factory.js
@@ -29,6 +29,8 @@ const injectQuery = ({ deletedField, }) => Query => class SoftDeleteQuery extend
         [NOT_IS]: true,
       };
     }
+
+    return super.prepareQuery();
   }
 
   /**

--- a/packages/ilorm/lib/query/query.class.js
+++ b/packages/ilorm/lib/query/query.class.js
@@ -198,7 +198,7 @@ let Query = class Query {
       });
     }
 
-    if (onSelect) {
+    if (onSelect && this[SELECT] && this[SELECT].fields && this[SELECT].fields.length > 0) {
       this[SELECT].fields.forEach(field => onSelect({ field, }));
     }
 

--- a/packages/ilorm/lib/query/query.class.js
+++ b/packages/ilorm/lib/query/query.class.js
@@ -239,10 +239,8 @@ let Query = class Query {
    * @returns {void} Return nothing, only change the internal state of query
    */
   prepareQuery() {
-    if (!this[SELECT]) {
-      this[SELECT] = {
-        behavior: SELECT_BEHAVIOR.ALL,
-      };
+    if (Object.keys(this[SELECT]).length === 0) {
+      this[SELECT].behavior = SELECT_BEHAVIOR.ALL;
 
       return;
     }
@@ -251,8 +249,8 @@ let Query = class Query {
       fields: [],
     };
 
-    for (const key of this[SELECT]) {
-      const operation = this[SELECT][key];
+    for (const key of Object.keys(this[SELECT])) {
+      const [ operation, ] = Object.keys(this[SELECT][key]);
 
       if (operation === OPERATIONS.SELECT_ONLY) {
         if (select.behavior !== null) {
@@ -271,7 +269,8 @@ let Query = class Query {
       }
     }
 
-    this[SELECT] = select;
+    this[SELECT].behavior = select.behavior;
+    this[SELECT].fields = select.fields;
 
     return;
   }

--- a/packages/ilorm/lib/query/query.class.js
+++ b/packages/ilorm/lib/query/query.class.js
@@ -3,7 +3,7 @@
 'use strict';
 
 
-const { FIELDS, SELECT_BEHAVIOR, OPERATIONS, } = require('ilorm-constants').QUERY;
+const { FIELDS, SELECT_BEHAVIOR, SORT_BEHAVIOR, OPERATIONS, } = require('ilorm-constants').QUERY;
 const { CONNECTOR, LIMIT, MODEL, QUERY, QUERY_OR, SCHEMA, SELECT, SKIP, SORT, UPDATE, } = FIELDS;
 const { Transform, } = require('stream');
 
@@ -187,7 +187,7 @@ let Query = class Query {
    * @param {Function} onSelect This function will be called to handle select specific fields from the database
    * @returns {void} Return nothing
    */
-  queryBuilder({ onOr, onOperator, onOptions, onSelect, }) {
+  queryBuilder({ onOr, onOperator, onOptions, onSelect, onSort, }) {
     if (onOr) {
       if (this[QUERY_OR]) {
         this[QUERY_OR].forEach(onOr);
@@ -199,6 +199,19 @@ let Query = class Query {
         skip: this[SKIP],
         limit: this[LIMIT],
       });
+    }
+
+    if (onSort) {
+      const query = this[QUERY];
+
+      for (const key of Object.keys(query)) {
+        for (const operator of Object.keys(query[key])) {
+          onSort({
+            key,
+            order: operator === OPERATIONS.SORT_ASCENDING ? SORT_BEHAVIOR.ASCENDING : SORT_BEHAVIOR.DESCENDING,
+          });
+        }
+      }
     }
 
     if (onSelect && this[SELECT] && this[SELECT].fields && this[SELECT].fields.length > 0) {

--- a/packages/ilorm/lib/query/query.class.js
+++ b/packages/ilorm/lib/query/query.class.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const { SCHEMA, MODEL, CONNECTOR, QUERY, QUERY_OR, UPDATE, SKIP, LIMIT, } = require('ilorm-constants').QUERY.FIELDS;
+const { FIELDS, } = require('ilorm-constants').QUERY;
+const { CONNECTOR, LIMIT, MODEL, QUERY, QUERY_OR, SCHEMA, SELECT, SKIP, SORT, UPDATE, } = FIELDS;
 const { Transform, } = require('stream');
 
 /**

--- a/packages/ilorm/lib/query/query.class.js
+++ b/packages/ilorm/lib/query/query.class.js
@@ -202,10 +202,10 @@ let Query = class Query {
     }
 
     if (onSort) {
-      const query = this[QUERY];
+      const sort = this[SORT];
 
-      for (const key of Object.keys(query)) {
-        for (const operator of Object.keys(query[key])) {
+      for (const key of Object.keys(sort)) {
+        for (const operator of Object.keys(sort[key])) {
           onSort({
             key,
             order: operator === OPERATIONS.SORT_ASCENDING ? SORT_BEHAVIOR.ASCENDING : SORT_BEHAVIOR.DESCENDING,

--- a/packages/ilorm/lib/query/query.class.js
+++ b/packages/ilorm/lib/query/query.class.js
@@ -1,4 +1,7 @@
+// eslint-disable-line max-lines
+
 'use strict';
+
 
 const { FIELDS, SELECT_BEHAVIOR, OPERATIONS, } = require('ilorm-constants').QUERY;
 const { CONNECTOR, LIMIT, MODEL, QUERY, QUERY_OR, SCHEMA, SELECT, SKIP, SORT, UPDATE, } = FIELDS;

--- a/packages/ilorm/lib/query/query.factory.js
+++ b/packages/ilorm/lib/query/query.factory.js
@@ -3,7 +3,7 @@
  */
 
 const { getQuery, } = require('./query.class');
-const { SCHEMA, MODEL, CONNECTOR, QUERY, UPDATE, } = require('ilorm-constants').QUERY.FIELDS;
+const { SCHEMA, MODEL, CONNECTOR, QUERY, UPDATE, SORT, SELECT, } = require('ilorm-constants').QUERY.FIELDS;
 
 /**
  * Create a property option object (Object.defineProperty)
@@ -35,6 +35,8 @@ const queryFactory = ({ model, }) => {
     [CONNECTOR]: defineProperty(connector),
     [QUERY]: defineProperty({}),
     [UPDATE]: defineProperty({}),
+    [SORT]: defineProperty({}),
+    [SELECT]: defineProperty({}),
     [MODEL]: defineProperty(model),
   });
 

--- a/packages/ilorm/lib/schemaField/schemaField.class.js
+++ b/packages/ilorm/lib/schemaField/schemaField.class.js
@@ -101,6 +101,30 @@ let SchemaField = class SchemaField {
         field: FIELDS.UPDATE,
         key: name || this.name,
       }),
+      [OPERATIONS.SELECT]: declareOperation({
+        query,
+        operation: OPERATIONS.SELECT,
+        field: FIELDS.SELECT,
+        key: name || this.name,
+      }),
+      [OPERATIONS.SELECT_ONLY]: declareOperation({
+        query,
+        operation: OPERATIONS.SELECT_ONLY,
+        field: FIELDS.SELECT,
+        key: name || this.name,
+      }),
+      [OPERATIONS.SORT_ASCENDING]: declareOperation({
+        query,
+        operation: OPERATIONS.SORT_ASCENDING,
+        field: FIELDS.SORT,
+        key: name || this.name,
+      }),
+      [OPERATIONS.SORT_DESCENDING]: declareOperation({
+        query,
+        operation: OPERATIONS.SORT_DESCENDING,
+        field: FIELDS.SORT,
+        key: name || this.name,
+      }),
     };
 
     SCHEMA_FIELDS_OPERATIONS


### PR DESCRIPTION
- Add .useAsSortAsc() : To sort query ascending by the field.
- Add .useAsSortDesc() : To query descending by the field.
- Add .select() : To select only specific field from the query result.
- Add .selectOnly() : To select only one field from the query result and returning it directly.